### PR TITLE
Fix overflow error for high losses by using np.longdouble

### DIFF
--- a/server.py
+++ b/server.py
@@ -212,8 +212,12 @@ class State:
             tokeninfo["token"] = self.tokenizer.decode([tokenid])
 
             tok_losses = losses[ii-1]
+
+            if tok_losses.sum() > 500:
+                tok_losses = np.array(tok_losses, dtype=np.longdouble)
+            
             total = np.exp(tok_losses).sum()
-            pprob = math.exp(tok_losses[tokenid])
+            pprob = np.exp(tok_losses[tokenid])
             prob = pprob / total
 
             new_entropy = math.log2(1.0 / prob)


### PR DESCRIPTION
When `tok_losses` is especially high (mostly when using smaller models like `pythia-70M`), the exponentiation can cause an overflow error. To fix this, when `tok_losses.sum()` is over 500, it is converted to an `np.longdouble` array.

Notes:
- I also tried the python builtin [decimal](https://docs.python.org/3/library/decimal.html) library, but it was very slow, and took up most of the time in each iteration.
- I used python to generate random arrays of numbers that equal `x`, and then found the amount where `np.exp(array).sum()` was equal `inf`. 500 is a good point to switch.